### PR TITLE
Feature: autoheal

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -71,6 +71,18 @@ services:
       - db
       - cache
       - seeder
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/health_checks/default"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+  autoheal:
+    image: willfarrell/autoheal
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: all
 
   worker:
     <<: *app


### PR DESCRIPTION
I was not aware docker-compose doesn't do this by default.

The specific case that prompted this was that OpenProject ran into an infinite loop making the process completely unresponsive but the container was still considered healthy by docker.

I've added a healthcheck to make sure the unhealthy condition is actually recognized.
But even then the container is only shown as unhealthy and not restarted.

Hence I've added the autoheal service.