### PR TITLE
Make Healthcheck comply to relative root

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     labels:
       - autoheal=true
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-/}/health_checks/default"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}/health_checks/default"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     labels:
       - autoheal=true
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health_checks/default"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-/}/health_checks/default"]
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
We recently updated our self-hosted openproject from 11 to 12 and switched from our own setup to the setup provided by this repository.
Our instance was reachable and we could work with it but the connection got interrupted every ~10-20 seconds.
I noticed that the web container was caught in a restart loop after we made the switch.

# Issue
You can reproduce the issue using the "reproduce-issue" branch of my fork.
After upping the containers you will see the restart loop caused by the failing healthcheck.
```
compose-autoheal-1  | 03-01-2022 10:01:15 Container /compose-web-1 (5a2688efdb04) found to be unhealthy - Restarting container now with 10s timeout
compose-autoheal-1  | 03-01-2022 10:02:11 Container /compose-web-1 (5a2688efdb04) found to be unhealthy - Restarting container now with 10s timeout
```
```
compose-web-1  | -----> Setting PGVERSION=13 PGBIN=/usr/lib/postgresql/13/bin PGCONF_FILE=/etc/postgresql/13/main/postgresql.conf
compose-web-1  | => Booting Puma
compose-web-1  | => Rails 6.1.4.1 application starting in production 
compose-web-1  | => Run `bin/rails server --help` for more startup options
compose-web-1  | W, [2022-01-03T10:00:28.837197 #1]  WARN -- : Creating scope :open. Overwriting existing method GithubPullRequest.open.
compose-web-1  | [1] Puma starting in cluster mode...
compose-web-1  | [1] * Puma version: 5.5.2 (ruby 2.7.5-p203) ("Zawgyi")
compose-web-1  | [1] *  Min threads: 4
compose-web-1  | [1] *  Max threads: 16
compose-web-1  | [1] *  Environment: production
compose-web-1  | [1] *   Master PID: 1
compose-web-1  | [1] *      Workers: 2
compose-web-1  | [1] *     Restarts: (✔) hot (✖) phased
compose-web-1  | [1] * Preloading application
compose-web-1  | [1] * Listening on http://0.0.0.0:8080
compose-web-1  | [1] Use Ctrl-C to stop
compose-web-1  | [1] - Worker 0 (PID: 35) booted in 0.01s, phase: 0
compose-web-1  | [1] - Worker 1 (PID: 41) booted in 0.0s, phase: 0
compose-web-1  | [1] === puma shutdown: 2022-01-03 10:01:15 +0000 ===
compose-web-1  | [1] - Goodbye!
compose-web-1  | [1] - Gracefully shutting down workers...
compose-web-1  | Exiting
compose-web-1  | -----> Setting PGVERSION=13 PGBIN=/usr/lib/postgresql/13/bin PGCONF_FILE=/etc/postgresql/13/main/postgresql.conf
compose-web-1  | => Booting Puma
compose-web-1  | => Rails 6.1.4.1 application starting in production 
compose-web-1  | => Run `bin/rails server --help` for more startup options
compose-web-1  | W, [2022-01-03T10:01:24.090932 #1]  WARN -- : Creating scope :open. Overwriting existing method GithubPullRequest.open.
compose-web-1  | [1] Puma starting in cluster mode...
compose-web-1  | [1] * Puma version: 5.5.2 (ruby 2.7.5-p203) ("Zawgyi")
compose-web-1  | [1] *  Min threads: 4
compose-web-1  | [1] *  Max threads: 16
compose-web-1  | [1] *  Environment: production
compose-web-1  | [1] *   Master PID: 1
compose-web-1  | [1] *      Workers: 2
compose-web-1  | [1] *     Restarts: (✔) hot (✖) phased
compose-web-1  | [1] * Preloading application
compose-web-1  | [1] * Listening on http://0.0.0.0:8080
compose-web-1  | [1] Use Ctrl-C to stop
compose-web-1  | [1] - Worker 0 (PID: 34) booted in 0.01s, phase: 0
compose-web-1  | [1] - Worker 1 (PID: 40) booted in 0.0s, phase: 0
compose-web-1  | [1] === puma shutdown: 2022-01-03 10:02:11 +0000 ===
compose-web-1  | [1] - Goodbye!
compose-web-1  | [1] - Gracefully shutting down workers...
compose-web-1  | Exiting
```

# Issue
The issue rises from our .env file where we are using
```
OPENPROJECT_RAILS__RELATIVE__URL__ROOT="/open_project"
```
but the healthcheck of the webcontainer does not comply to this relative root, which you can verify manually
```
docker exec -it compose-web-1 curl -f http://localhost:8080/health_checks/default
-> curl: (22) The requested URL returned error: 404 Not Found
```
```
docker exec -it compose-web-1 curl -f http://localhost:8080/open_project/health_checks/default 
-> default: PASSED Application is running (0.000s)        
```

# Solution
The solution is to simply integrate OPENPROJECT_RAILS__RELATIVE__URL__ROOT to the web containers healthcheck.

## Verify the solution
You can also verify the provided solution by checking the "fixed-issue" branch of my fork.
