### PR TITLE
Parameterises data volumes & postgress password

### DIFF
--- a/compose/docker-compose.control.yml
+++ b/compose/docker-compose.control.yml
@@ -14,7 +14,7 @@ services:
     environment:
       PGDATA: /var/lib/postgresql/data
     volumes:
-      - "pgdata:/var/lib/postgresql/data"
+      - "${PGDATA:-pgdata}:/var/lib/postgresql/data"
       - "./control:/control"
     entrypoint: ["/control/upgrade/entrypoint.sh"]
   backup:
@@ -25,8 +25,8 @@ services:
       PGDATA: /var/lib/postgresql/data
       OPDATA: /var/openproject/assets
     volumes:
-      - "pgdata:/var/lib/postgresql/data"
-      - "opdata:/var/openproject/assets"
+      - "${PGDATA:-pgdata}:/var/lib/postgresql/data"
+      - "${OPDATA:-opdata}:/var/openproject/assets"
       - "./backups:/backups"
       - "./control:/control"
     entrypoint: ["/control/backup/entrypoint.sh"]

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - "${PGDATA:-pgdata}:/var/lib/postgresql/data"
     environment:
-      POSTGRES_PASSWORD: "${POSTGRES_PSWD:-p4ssw0rd}"
+      POSTGRES_PASSWORD: ${POSTGRES_PSWD:-p4ssw0rd}
       POSTGRES_DB: openproject
     networks:
       - backend

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -25,7 +25,7 @@ x-op-app: &app
     # set to true to enable the email receiving feature. See ./docker/cron for more options
     IMAP_ENABLED: "${IMAP_ENABLED:-false}"
   volumes:
-    - "opdata:/var/openproject/assets"
+    - "${OPDATA:-opdata}:/var/openproject/assets"
 
 services:
   db:
@@ -33,7 +33,7 @@ services:
     <<: *restart_policy
     stop_grace_period: "3s"
     volumes:
-      - "pgdata:/var/lib/postgresql/data"
+      - "${PGDATA:-pgdata}:/var/lib/postgresql/data"
     environment:
       POSTGRES_PASSWORD: p4ssw0rd
       POSTGRES_DB: openproject

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - "${PGDATA:-pgdata}:/var/lib/postgresql/data"
     environment:
-      POSTGRES_PASSWORD: p4ssw0rd
+      POSTGRES_PASSWORD: "${POSTGRES_PSWD:-p4ssw0rd}"
       POSTGRES_DB: openproject
     networks:
       - backend
@@ -112,3 +112,4 @@ services:
     restart: on-failure
     networks:
       - backend
+

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - "${PGDATA:-pgdata}:/var/lib/postgresql/data"
     environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PSWD:-p4ssw0rd}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-p4ssw0rd}
       POSTGRES_DB: openproject
     networks:
       - backend


### PR DESCRIPTION
- The defaults are set so that the volumes remains the same but if you want to set a path to mount instead you can set that in environment variables and not use volumes
- The postgres password is parameterised in the database URL but not on the database so I added a variable for it on the database container.