### PR TITLE
Show available env vars

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -1,1 +1,18 @@
 PORT=8080
+
+# DockerHub Tag
+# TAG=12
+
+# Modifies the subdirectory path
+# OPENPROJECT_RAILS__RELATIVE__URL__ROOT="/openproject"
+
+# Database Link
+# DATABASE_URL="postgres://postgres:p4ssw0rd@db/openproject?pool=20&encoding=unicode&reconnect=true"
+
+# IMAP_ENABLED=false
+
+# Storage location for Open Project Data
+# OPDATA="/var/openproject/assets"
+
+# Storage Location for postgres data
+# PGDATA="/var/lib/postgresql/data"


### PR DESCRIPTION
Instead of forcing the user to search available environment variables inside the docker config, it is appropriate to add a commented version of the key-value pairs.