### PR TITLE
Set default listen port to ::1:8080

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -22,7 +22,8 @@ After a while, OpenProject should be up and running on <http://localhost:8080>.
 
 ## Configuration
 
-If you want to specify a different port, you can do so with:
+By default, the application will be bound to localhost:8080 on the docker host only. If you need to publicly expose the port 
+or change the port to something else entirely, you can do so with:
 
     PORT=4000 docker-compose up -d
 

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     <<: *restart_policy
     command: "./docker/prod/proxy"
     ports:
-      - "${PORT:-8080}:80"
+      - "${PORT:-::1:8080}:80"
     environment:
       APP_HOST: web
       OPENPROJECT_RAILS__RELATIVE__URL__ROOT: "${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}"


### PR DESCRIPTION
Set a reasonable default listen port for the container. Suggested by Gunther Ohrner, patch submitted via email.