### PR TITLE
Compatibility with Portainer (Widely used Docker Control Panel)

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -13,8 +13,7 @@ x-op-restart-policy: &restart_policy
 x-op-image: &image
   image: openproject/community:${TAG:-12}
 x-op-app: &app
-  <<: *image
-  <<: *restart_policy
+  <<: [*image, *restart_policy]
   environment:
     RAILS_CACHE_STORE: "memcache"
     OPENPROJECT_CACHE__MEMCACHE__SERVER: "cache:11211"
@@ -47,8 +46,7 @@ services:
       - backend
 
   proxy:
-    <<: *image
-    <<: *restart_policy
+    <<: [*image, *restart_policy]
     command: "./docker/prod/proxy"
     ports:
       - "${PORT:-8080}:80"


### PR DESCRIPTION
While deploying stacks (`docker-compose`) using Portainer, the web interface does not allow the `.yml` file to have two `<<` tags in the same level. Therefore replacing two of them as one in brackets solves the issue.

This configuration works both with the Portainer web interface and the docker-compose cli without any problems.
Know more about Portainer at https://www.portainer.io/