### PR TITLE
Allow non ssl connections

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -15,6 +15,9 @@ x-op-image: &image
 x-op-app: &app
   <<: [*image, *restart_policy]
   environment:
+    OPENPROJECT_HTTPS: "false"
+    OPENPROJECT_HOST__NAME: "localhost:8080"
+    OPENPROJECT_HSTS: "false"
     RAILS_CACHE_STORE: "memcache"
     OPENPROJECT_CACHE__MEMCACHE__SERVER: "cache:11211"
     OPENPROJECT_RAILS__RELATIVE__URL__ROOT: "${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}"


### PR DESCRIPTION
Adding these env vars to the docker-compose.yml
OPENPROJECT_HTTPS, OPENPROJECT_HOST__NAME, OPENPROJECT_HSTS
See Issue #38