### PR TITLE
feat: set default TAG in `.env.example` as version 13

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -6,7 +6,7 @@
 # Please refer to our documentation to see all possible variables:
 #   https://www.openproject.org/docs/installation-and-operations/configuration/environment/
 #
-TAG=12
+TAG=13
 OPENPROJECT_HTTPS=false
 OPENPROJECT_HOST__NAME=localhost
 PORT=127.0.0.1:8080


### PR DESCRIPTION
This PR sets the default value for the `TAG` environment variable in the `.env.example` to be `13`