### PR TITLE
[Version > 14] apply docker registry renaming

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
 x-op-restart-policy: &restart_policy
   restart: unless-stopped
 x-op-image: &image
-  image: openproject/community:${TAG:-14}
+  image: openproject/openproject:${TAG:-14}
 x-op-app: &app
   <<: [*image, *restart_policy]
   environment:


### PR DESCRIPTION
> Starting with OpenProject 14.0, docker images will be published to [openproject/openproject](https://hub.docker.com/r/openproject/openproject) on Docker Hub. If your setup is still using the old image name (openproject/community), you will need to update your configuration to use the new image names.

This PR applies the new openproject namespace starting with 14.0.0