### PR TITLE
[chore] added documentation to the Caddyfile

### DIFF
--- a/compose/Caddyfile.template
+++ b/compose/Caddyfile.template
@@ -1,7 +1,16 @@
 :80 {
     root * /public
 
-    reverse_proxy * http://${APP_HOST}:8080
+    reverse_proxy * http://${APP_HOST}:8080 {
+        # If your are using a reverse proxy in front of the compose stack, there might be
+        # an issue with caddy stripping certain X-Forwarded-* headers.
+        # For more information see: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#defaults
+        # It is strongly recommended to configure this via the server's global `trusted_proxies` directive.
+        # See: https://caddyserver.com/docs/caddyfile/options#trusted-proxies
+        # If you are aware of the risks, the simple option is to just add the needed `header_up` directives manually:
+        #
+        # header_up X-Forwarded-Proto "https"
+    }
 
     file_server
 

--- a/compose/Caddyfile.template
+++ b/compose/Caddyfile.template
@@ -2,14 +2,15 @@
     root * /public
 
     reverse_proxy * http://${APP_HOST}:8080 {
-        # If your are using a reverse proxy in front of the compose stack, there might be
-        # an issue with caddy stripping certain X-Forwarded-* headers.
-        # For more information see: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#defaults
-        # It is strongly recommended to configure this via the server's global `trusted_proxies` directive.
-        # See: https://caddyserver.com/docs/caddyfile/options#trusted-proxies
-        # If you are aware of the risks, the simple option is to just add the needed `header_up` directives manually:
-        #
-        # header_up X-Forwarded-Proto "https"
+        # The following directives are needed to make the proxy forward explicitly the X-Forwarded-* headers. If unset,
+        # Caddy will reset them. See: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#defaults
+        # This is needed, if you are using a reverse proxy in front of the compose stack and Caddy is NOT your first
+        # point of contact.
+        # When using Caddy is reachable as a first point of contact, it is highly recommended to configure the server's
+        # global `trusted_proxies` directive. See: https://caddyserver.com/docs/caddyfile/options#trusted-proxies
+
+        header_up X-Forwarded-Proto {header.X-Forwarded-Proto}
+        header_up X-Forwarded-For {header.X-Forwarded-For}
     }
 
     file_server

--- a/compose/README.md
+++ b/compose/README.md
@@ -30,7 +30,7 @@ docker compose up -d
 
 After a while, OpenProject should be up and running on <http://localhost:8080>.
 
-**HTTPS/SSL**
+### HTTPS/SSL
 
 By default OpenProject starts with the HTTPS option **enabled**, but it **does not** handle SSL termination itself. This
 is usually done separately via a [reverse proxy
@@ -39,7 +39,10 @@ Without this you will run into an `ERR_SSL_PROTOCOL_ERROR` when accessing OpenPr
 
 See below how to disable HTTPS.
 
-**PORT**
+If there is an issue with `X-Forwarded-*` headers being stripped from the reverse proxy requests, please consider
+checking the commented directives in the `Caddyfile.template` and read the instructions carefully.
+
+### PORT
 
 By default the port is bound to `0.0.0.0` means access to OpenProject will be public.
 See below how to change that.
@@ -128,7 +131,6 @@ If you're running into weird network issues and timeouts such as the one describ
 frontend and backend networks. This might be connected to using podman for orchestration, although we haven't been able
 to confirm this.
 
-
 ### SMTP setup fails: Network is unreachable.
 
 Make sure your container has DNS resolution to access external SMTP server when set up as described in
@@ -136,6 +138,6 @@ Make sure your container has DNS resolution to access external SMTP server when 
 
 ```yml
 worker:
-   dns:
-     - "Your DNS IP" # OR add a public DNS resolver like 8.8.8.8
+  dns:
+    - "Your DNS IP" # OR add a public DNS resolver like 8.8.8.8
  ```

--- a/compose/README.md
+++ b/compose/README.md
@@ -39,8 +39,11 @@ Without this you will run into an `ERR_SSL_PROTOCOL_ERROR` when accessing OpenPr
 
 See below how to disable HTTPS.
 
-If there is an issue with `X-Forwarded-*` headers being stripped from the reverse proxy requests, please consider
-checking the commented directives in the `Caddyfile.template` and read the instructions carefully.
+Be aware that if you want to use the integrated Caddy proxy as a proxy with outbound connections, you need to rewrite the
+`Caddyfile`. In the default state, it is configured to forward the `X-Forwarded-*` headers from the reverse proxy in
+front of it and not setting them itself. This is considered a security flaw and should instead be solved by configuring
+`trusted_proxies` inside the `Caddyfile`. For more information read
+the [Caddy documentation](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy).
 
 ### PORT
 


### PR DESCRIPTION
### WAT?

- tackle issue with users using the new extracted proxy service in combination with a reverse proxy with https in front
- additional information for usage with reverse proxies
  - in `Caddyfile.template` and `README.md`