### PR TITLE
[chore] extract volumes from app anchor

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -25,8 +25,6 @@ x-op-app: &app
     RAILS_MAX_THREADS: ${RAILS_MAX_THREADS:-16}
     # set to true to enable the email receiving feature. See ./docker/cron for more options
     IMAP_ENABLED: "${IMAP_ENABLED:-false}"
-  volumes:
-    - "${OPDATA:-opdata}:/var/openproject/assets"
 
 services:
   db:
@@ -83,6 +81,7 @@ services:
       retries: 3
       start_period: 30s
     volumes:
+      - "${OPDATA:-opdata}:/var/openproject/assets"
       - assets:/app/public
 
   autoheal:
@@ -103,6 +102,8 @@ services:
       - db
       - cache
       - seeder
+    volumes:
+      - "${OPDATA:-opdata}:/var/openproject/assets"
 
   cron:
     <<: *app
@@ -113,6 +114,8 @@ services:
       - db
       - cache
       - seeder
+    volumes:
+      - "${OPDATA:-opdata}:/var/openproject/assets"
 
   seeder:
     <<: *app
@@ -120,4 +123,6 @@ services:
     restart: on-failure
     networks:
       - backend
+    volumes:
+      - "${OPDATA:-opdata}:/var/openproject/assets"
 


### PR DESCRIPTION
Fixes issue #71 

### WAT?

- yaml anchors do not support merging of lists
- to add specific volumes to a service, you cannot use an alias to include shared volumes
- hence, every service should do the volume definition by itself, once there is a single service that has a specific volume next to the common ones