### PR TITLE
Bug/58353 docker build the control plane fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 
 docker-compose.override.yml
+backups/

--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:10
+FROM debian:12
 
 RUN apt-get update -qq && apt-get install wget gnupg2 -y && rm -rf /var/lib/apt/lists/*
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update -qq && apt-get install postgresql-9.6 postgresql-10 postgresql-13 -y && rm -rf /var/lib/apt/lists/*
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 


### PR DESCRIPTION
[#58353] Docker: build the control plane fails

https://community.openproject.org/work_packages/58353

update controle plane container to debian:12 and change PostgreSQL repo because the repo for debian:10 doesn't exist anymore