### PR TITLE
Mount docker.sock readonly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
   autoheal:
     image: willfarrell/autoheal:1.2.0
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
     environment:
       AUTOHEAL_CONTAINER_LABEL: autoheal
       AUTOHEAL_START_PERIOD: 600


### PR DESCRIPTION
docker.sock can be mounted readonly without downsides and without the risk of deletion.