### PR TITLE
Refactor service dependencies in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,12 @@ x-op-app: &app
     IMAP_ENABLED: "${IMAP_ENABLED:-false}"
   volumes:
     - "${OPDATA:-opdata}:/var/openproject/assets"
+x-op-app-depends: &app-depends
+    depends_on:
+      seeder:
+        condition: service_completed_successfully
+      cache:
+        condition: service_started
 
 services:
   db:
@@ -56,20 +62,17 @@ services:
     ports:
       - "${PORT:-8080}:80"
     depends_on:
-      - web
+      web:
+        condition: service_healthy
     networks:
       - frontend
 
   web:
-    <<: *app
+    <<: [*app, *app-depends]
     command: "./docker/prod/web"
     networks:
       - frontend
       - backend
-    depends_on:
-      - db
-      - cache
-      - seeder
     labels:
       - autoheal=true
     healthcheck:
@@ -89,24 +92,16 @@ services:
       AUTOHEAL_INTERVAL: 30
 
   worker:
-    <<: *app
+    <<: [*app, *app-depends]
     command: "./docker/prod/worker"
     networks:
       - backend
-    depends_on:
-      - db
-      - cache
-      - seeder
 
   cron:
-    <<: *app
+    <<: [*app, *app-depends]
     command: "./docker/prod/cron"
     networks:
       - backend
-    depends_on:
-      - db
-      - cache
-      - seeder
 
   seeder:
     <<: *app
@@ -114,3 +109,5 @@ services:
     restart: on-failure
     networks:
       - backend
+    depends_on:
+      - db


### PR DESCRIPTION
fix service dependency ordering and startup conditions
- Ensured seeder completes successfully before dependent services start
- Introduced x-op-app-depends anchor to centralize app dependency logic
- Updated web, worker, and cron services to use structured depends_on with health/exit conditions
- Changed proxy to wait for web health check before starting