### PR TITLE
Addition of repository volume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,4 @@ RAILS_MIN_THREADS=4
 RAILS_MAX_THREADS=16
 PGDATA="/var/lib/postgresql/data"
 OPDATA="/var/openproject/assets"
+REPO_DIR="/repositories"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ networks:
 volumes:
   pgdata:
   opdata:
+  repodir:
 
 x-op-restart-policy: &restart_policy
   restart: unless-stopped
@@ -26,6 +27,7 @@ x-op-app: &app
     IMAP_ENABLED: "${IMAP_ENABLED:-false}"
   volumes:
     - "${OPDATA:-opdata}:/var/openproject/assets"
+    - "${REPO_DIR:-repodir}:/repositories"
 
 services:
   db:
@@ -73,7 +75,13 @@ services:
     labels:
       - autoheal=true
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}/health_checks/default"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:8080${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}/health_checks/default",
+        ]
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
In the web interface there is only linking to an existing local repository. Since this is a docker compose file, the containers that spin up can't point to any repositories except any residing in their local file system. As such we must expose the repos in some way.


<img width="971" height="548" alt="image" src="https://github.com/user-attachments/assets/41c1a07f-0c2a-4cca-9d6c-ef67e9c31677" />

The current PR does an addition of a repository volume in the Docker compose file. Also, it adds an environment variable in the example files where someone can change. eg:
`REPO_DIR="/volume1/docker/gitea/data/git/repositories"`