### PR TITLE
Parameterize postgres db and user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,10 @@ OPENPROJECT_HOST__NAME=localhost
 PORT=127.0.0.1:8080
 OPENPROJECT_RAILS__RELATIVE__URL__ROOT=
 IMAP_ENABLED=false
+POSTGRES_DB=openproject
+POSTGRES_USER=postgres
 POSTGRES_PASSWORD=p4ssw0rd
-DATABASE_URL="postgres://postgres:${POSTGRES_PASSWORD}@db/openproject?pool=20&encoding=unicode&reconnect=true"
+DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}?pool=20&encoding=unicode&reconnect=true"
 RAILS_MIN_THREADS=4
 RAILS_MAX_THREADS=16
 PGDATA="/var/lib/postgresql/data"

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,8 @@ OPENPROJECT_HOST__NAME=localhost
 PORT=127.0.0.1:8080
 OPENPROJECT_RAILS__RELATIVE__URL__ROOT=
 IMAP_ENABLED=false
-DATABASE_URL=postgres://postgres:p4ssw0rd@db/openproject?pool=20&encoding=unicode&reconnect=true
+POSTGRES_PASSWORD=p4ssw0rd
+DATABASE_URL="postgres://postgres:${POSTGRES_PASSWORD}@db/openproject?pool=20&encoding=unicode&reconnect=true"
 RAILS_MIN_THREADS=4
 RAILS_MAX_THREADS=16
 PGDATA="/var/lib/postgresql/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,9 @@ services:
     volumes:
       - "${PGDATA:-pgdata}:/var/lib/postgresql/data"
     environment:
+      POSTGRES_DB: ${POSTGRES_DB:-openproject}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-p4ssw0rd}
-      POSTGRES_DB: openproject
     networks:
       - backend
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://github.com/opf/openproject-docker-compose

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Continue the work made in #142: Creating more parameters in environment variables.

# What approach did you choose and why?
The same approach, but I am not sure if you would prefer to allow this flexibility or not, so I made it as a separate PR.

**IMPORTANT NOTE**:  There are documentations that will need to be changed if this gets merged, because the values for db or username are hard-coded there. An example that I faced, but not necessary the only one, is [migration-to-postgresql17](https://www.openproject.org/docs/installation-and-operations/misc/migration-to-postgresql17/)
I would suggest editing the commands to be like:
```
source .env
docker compose exec -it -u postgres db pg_dump -d ${POSTGRES_DB:-openproject} -U ${POSTGRES_USER:-postgres} -x -O > openproject.sql
```

Or assume the variables are always set?
```
source .env
docker compose exec -it -u postgres db pg_dump -d ${POSTGRES_DB} -U ${POSTGRES_USER} -x -O > openproject.sql
```

Side note: The quotation for `DATABASE_URL` makes `source` execute without misinterpretation (Otherwise, `&` in the URL creates a background job)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
