### PR TITLE
fix ssl redirects when using internal openproject url in hocuspocus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ services:
     environment:
       SECRET: ${COLLABORATIVE_SERVER_SECRET:-OVERRIDE_ME_PLEASE}
       OPENPROJECT_URL: "${OPENPROJECT_URL:-http://web:8080}"
+      OPENPROJECT_HTTPS: "${OPENPROJECT_HTTPS:-true}"
     networks:
       - backend
       - frontend


### PR DESCRIPTION
https://community.openproject.org/notifications/details/70542/activity

Depends on https://github.com/opf/op-blocknote-hocuspocus/pull/52

