### PR TITLE
backup use of OPENPROJECT_URL and OPENPROJECT_HTTPS to fix hocuspocus…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ x-op-app: &app
   environment:
     OPENPROJECT_HTTPS: "${OPENPROJECT_HTTPS:-true}"
     OPENPROJECT_HOST__NAME: "${OPENPROJECT_HOST__NAME:-localhost:8080}"
+    OPENPROJECT_ADDITIONAL__HOST__NAMES: "${OPENPROJECT_ADDITIONAL__HOST__NAMES:-web}" # to allow access from hocuspocus directly
     OPENPROJECT_HSTS: "${OPENPROJECT_HSTS:-true}"
     RAILS_CACHE_STORE: "memcache"
     OPENPROJECT_CACHE__MEMCACHE__SERVER: "cache:11211"
@@ -123,6 +124,8 @@ services:
     image: openproject/hocuspocus:17.0.3
     environment:
       SECRET: ${COLLABORATIVE_SERVER_SECRET:-OVERRIDE_ME_PLEASE}
+      OPENPROJECT_URL: "${OPENPROJECT_URL:-http://web:8080}"
+      OPENPROJECT_HTTPS: "${OPENPROJECT_HTTPS:-true}"
     networks:
       - backend
       - frontend


### PR DESCRIPTION
https://community.openproject.org/notifications/details/70542/activity

Depends on https://github.com/opf/op-blocknote-hocuspocus/pull/53