### PR TITLE
use postgres 17 for new installations, add upgrade hint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,4 @@ PGDATA="/var/lib/postgresql/data"
 OPDATA="/var/openproject/assets"
 COLLABORATIVE_SERVER_URL=ws://localhost:8080/hocuspocus
 COLLABORATIVE_SERVER_SECRET=secret12345
+POSTGRES_VERSION=17 # Note for existing setups: make sure this is the same version you are using right now, or upgrade your database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,13 @@ x-op-app: &app
 
 services:
   db:
-    image: postgres:13
+    # The default here should really be 17 but is still 13 as to not break existing setups.
+    # New installations using the provided .env.example will use 17 to begin with.
+    # The default here will change to 17 as well with the next major update (18).
+    #
+    # Refer to the docs on how to upgrade to postgres 17 before then:
+    #   https://www.openproject.org/docs/installation-and-operations/misc/migration-to-postgresql17/
+    image: postgres:${POSTGRES_VERSION:-13}
     <<: *restart_policy
     stop_grace_period: "3s"
     volumes:


### PR DESCRIPTION
The postgres version in our docker-compose.yml is very much outdated.
This PR makes the postgres version configurable to not immediately break existing installations, while setting the default for new ones to 17 as it should be.

With the next major version upgrade we will change the default to 17 for both cases.
People will have to upgrade their database. A link to the docs is provided.