### PR TITLE
Use ruby instead of curl to check web service health

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     labels:
       - autoheal=true
     healthcheck:
-      test: ["CMD", "ruby", "-e", "require 'net/http'; exit 1 unless Net::HTTP.get_response(URI('http://localhost:8080/health_checks/default')).is_a?(Net::HTTPSuccess)"]
+      test: ["CMD", "ruby", "-e", "require 'net/http'; exit 1 unless Net::HTTP.get_response(URI('http://localhost:8080${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}/health_checks/default')).is_a?(Net::HTTPSuccess)"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     labels:
       - autoheal=true
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}/health_checks/default"]
+      test: ["CMD", "ruby", "-e", "require 'net/http'; exit 1 unless Net::HTTP.get_response(URI('http://localhost:8080/health_checks/default')).is_a?(Net::HTTPSuccess)"]
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
Hello, I have created this pull request in an effort to help others that experienced a problem with the health checker when using the slim images. The slim docker images do not contain curl causing the healthcheck to fail and the container to be continually restarted by autoheal.

# Ticket
[Healthcheck for web container fails! #150](https://github.com/opf/openproject-docker-compose/issues/150)

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
To enable autoheal to correctly identify a healthy container when using the slim docker images.

# What approach did you choose and why?
The openproject code base is written in ruby meaning that the slim docker container is guaranteed to have ruby installed. A one-liner ruby script is how I solved this on my local install.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
