### PR TITLE
Improve database configuration and volume management in Docker setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,11 +17,16 @@ OPENPROJECT_HOST__NAME=localhost
 PORT=127.0.0.1:8080
 OPENPROJECT_RAILS__RELATIVE__URL__ROOT=
 IMAP_ENABLED=false
+# Must match the password in DATABASE_URL. The db service uses POSTGRES_PASSWORD only on first DB init (new volume).
+POSTGRES_PASSWORD=p4ssw0rd
 DATABASE_URL=postgres://postgres:p4ssw0rd@db/openproject?pool=20&encoding=unicode&reconnect=true
 RAILS_MIN_THREADS=4
 RAILS_MAX_THREADS=16
-PGDATA="/var/lib/postgresql/data"
-OPDATA="/var/openproject/assets"
+# Compose volume source: use a name like pgdata for a Docker named volume. Do not set this to /var/lib/postgresql/data
+# unless you intend a bind mount; a reused directory may keep an old postgres password and break auth.
+PGDATA=pgdata
+# Same idea for OpenProject attachments/assets (named volume vs host path).
+OPDATA=opdata
 COLLABORATIVE_SERVER_URL=ws://localhost:8080/hocuspocus
 COLLABORATIVE_SERVER_SECRET=secret12345
 POSTGRES_VERSION=17 # Note for existing setups: make sure this is the same version you are using right now, or upgrade your database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ x-op-app: &app
     OPENPROJECT_RAILS__RELATIVE__URL__ROOT: "${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}"
     OPENPROJECT_COLLABORATIVE__EDITING__HOCUSPOCUS__URL: "${COLLABORATIVE_SERVER_URL:-wss://${OPENPROJECT_HOST__NAME}/hocuspocus}"
     OPENPROJECT_COLLABORATIVE__EDITING__HOCUSPOCUS__SECRET: "${COLLABORATIVE_SERVER_SECRET:-OVERRIDE_ME_PLEASE}"
-    DATABASE_URL: "${DATABASE_URL:-postgres://postgres:p4ssw0rd@db/openproject?pool=20&encoding=unicode&reconnect=true}"
+    DATABASE_URL: "${DATABASE_URL:-postgres://postgres:${POSTGRES_PASSWORD:-p4ssw0rd}@db/openproject?pool=20&encoding=unicode&reconnect=true}"
     RAILS_MIN_THREADS: ${RAILS_MIN_THREADS:-4}
     RAILS_MAX_THREADS: ${RAILS_MAX_THREADS:-16}
     # set to true to enable the email receiving feature. See ./docker/cron for more options
@@ -62,6 +62,7 @@ services:
       args:
         APP_HOST: web
     image: openproject/proxy
+    pull_policy: build # image is built from ./proxy, not pulled
     <<: *restart_policy
     ports:
       - "${PORT:-8080}:80"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/docker/work_packages/73743/activity

# What are you trying to accomplish?

Improve the Docker Compose developer/operator experience for the bundled `openproject-docker-compose` setup by:

1. **Proxy service** – Compose was attempting to pull `openproject/proxy` from a registry even though that image is only produced by the local `./proxy` build, which led to pull errors (e.g. “pull access denied” / “repository does not exist”) on `docker compose up` depending on Compose version and pull policy.
2. **PostgreSQL credentials** – Document and align `POSTGRES_PASSWORD` with `DATABASE_URL`, and default `DATABASE_URL` in `docker-compose.yml` to derive from `POSTGRES_PASSWORD` when `DATABASE_URL` is unset, so the app and `db` service stay in sync.
3. **Volume configuration in `.env.example`** – Replace misleading `PGDATA` / `OPDATA` values that looked like in-container paths but were interpreted as **bind-mount sources** (e.g. `/var/lib/postgresql/data`), which reused existing clusters and caused persistent “password authentication failed for user postgres” when the password in `.env` did not match the already-initialized database. The example now uses **named volumes** (`pgdata`, `opdata`) and short comments explaining the semantics.

## Screenshots
N/A (configuration and documentation only).

# What approach did you choose and why?

- **`pull_policy: build` on `proxy`** – Tells Compose to build from `./proxy` and not pull `openproject/proxy` from a registry. Minimal change; matches how the image is actually produced.
- **`DATABASE_URL` default with `${POSTGRES_PASSWORD}`** – Single source of truth for the default password when users omit an explicit `DATABASE_URL`, reducing drift between `db` and app containers.
- **`.env.example` with `POSTGRES_PASSWORD`, `PGDATA=pgdata`, `OPDATA=opdata`** – Matches common Compose usage, avoids accidental bind mounts to host paths, and documents that `POSTGRES_PASSWORD` only applies on **first** database initialization.

**Tradeoffs:** Users who intentionally used bind mounts to host paths must set `PGDATA` / `OPDATA` explicitly to those paths; the sample no longer encodes that pattern.

**Alternatives considered:** Renaming env vars (e.g. `POSTGRES_DATA_VOLUME`) would be clearer but diverges further from upstream naming and existing docs; skipped for a smaller, reviewable change.

**Follow-up (optional, separate change):** Align `README.md` sections that still assume `/var/openproject/assets` on the host with the new named-volume default in `.env.example`.